### PR TITLE
Add bellwether blogpost: from AI code to merged PR

### DIFF
--- a/.agents/skills/blog-voice/SKILL.md
+++ b/.agents/skills/blog-voice/SKILL.md
@@ -1,0 +1,109 @@
+# Blog Voice
+
+Write technical blog posts in the style of Andrej Karpathy — one of the clearest technical writers working today.
+
+## When to Use
+
+Invoke this skill whenever writing or editing a post for vanderveer.be. The goal is not imitation but internalization: write the way a senior engineer would if they cared about being genuinely useful to the reader.
+
+## The Core Orientation
+
+Karpathy writes like he's sharing something he actually figured out, not teaching a lesson he already knew. The reader gets to watch him think. That's the thing to replicate.
+
+The posture is: **I found something interesting. Let me show you what I saw and why it matters.**
+
+Not: here is a framework. Not: follow these five steps. Not: research shows.
+
+## Voice
+
+**First person, always.** "I" is the protagonist. "We" only when genuinely a team effort and the team matters to the story. Never the academic "one" or the corporate "the team."
+
+**Observational, not prescriptive.** The writer notices things. The reader draws conclusions. You can share what you concluded, but you don't tell the reader what they should do.
+
+> Good: "I stopped doing X and the codebase got easier to navigate."
+> Bad: "You should stop doing X."
+
+**Intellectually honest.** Acknowledge what you don't know. Say "I think" when you think, not when you know. Say "I'm not sure why" when you're not sure. This is not weakness — it's the thing that makes technical writing trustworthy.
+
+> Good: "This probably works because of X, though I haven't verified that."
+> Bad: "This works because of X."
+
+**Casual but precise.** "kinda", "roughly", "basically", "at some point" are fine. Vague technical claims are not. The informality is in how you hold ideas, not in the ideas themselves.
+
+**Dry humor is welcome.** Not jokes. Not wit for its own sake. But if something is genuinely funny about how you learned a thing, say so.
+
+## Structure
+
+**Open with something specific.** Not a thesis statement. A moment, an observation, a number, a thing that happened. The generalization can come later.
+
+> Good: "I spent three days convinced the bug was in the tokenizer. It was not in the tokenizer."
+> Bad: "Context window management is one of the most underappreciated challenges in LLM development."
+
+**Let the structure emerge from the content.** Not every post needs headers. When you use headers, make them statements or specific observations, not topic labels.
+
+> Good: "The tokenizer was fine"
+> Bad: "Background" / "Problem" / "Solution"
+
+**Short sentences land harder after long ones.** Vary the rhythm. A long explanatory paragraph followed by a two-word sentence does more than three medium sentences.
+
+**Build intuition, not just information.** The reader should leave understanding *why*, not just *what*. If you can't explain why something works the way it does, say so — that's interesting too.
+
+**End with reflection, not a bow.** Don't summarize. Don't list takeaways. Don't say "in conclusion." The post can just... end. Ideally with something that opens out — a question, an implication, a thing you're still thinking about.
+
+## Anti-Patterns
+
+These are the tells of AI-written or corporate blog posts. Avoid them.
+
+**Rhetorical lead-ins:**
+- "Here's the thing:" / "Here's what I found:" / "Here's the uncomfortable truth:"
+- "What surprised me most was..."
+- "The key insight is..."
+- "The bottom line:"
+
+These phrases announce an insight instead of delivering it. Just deliver it.
+
+**Prescriptive imperatives:**
+- "You should..." / "Teams need to..." / "The answer is to..."
+- "The winning teams will be those who..."
+- "This is [X] done right."
+
+**Marketing language:**
+- "10x productivity" / "force multiplier" / "game-changing"
+- "In my experience..." as throat-clearing
+- CTAs disguised as humility: "We've open-sourced..." at the end
+
+**Clean narrative arcs.** Real technical work is messy. A post that goes problem → insight → clean solution → results feels written. Show the detour you took, the thing that didn't work, the thing you still don't understand.
+
+**Numbered lists as a structure crutch.** Lists are fine for actual enumerations (steps, tools, config options). They're lazy when used to avoid writing real paragraphs about something you haven't fully thought through.
+
+## On Length
+
+Karpathy writes very long posts when the subject warrants it. Length is earned by having more to say, not by padding. A 500-word post that says one sharp thing clearly is better than a 2000-word post that says the same thing with scaffolding.
+
+## On Technical Content
+
+Code is a first-class citizen. When the code is the thing, show the code. Don't summarize what the code does when you can show the code.
+
+Numbers and specifics make claims real. "About 60% of time went to debugging" > "most of the time went to debugging". Exact error messages, exact command outputs, exact version numbers — these signal that you actually did the thing.
+
+Historical context matters. How did we end up here? Why does this work this way and not some other way? Understanding the path often explains the current state better than describing the current state directly.
+
+## Workflow
+
+When writing a new post:
+1. Start with what you actually noticed/learned, not with what you want to convey
+2. Write a rough draft without worrying about structure
+3. Find the sharpest observation in the draft — that's probably the real opening
+4. Cut everything that's scaffolding (throat-clearing, transitions that explain what you're about to do, summaries of what you just said)
+5. Read it aloud. Anything that sounds like a corporate blog post, rewrite
+
+When editing an existing AI-written post:
+1. Identify the 2-3 things the post actually has to say
+2. Find the most specific/concrete moment in the post — that's probably the real opening
+3. Rewrite section by section, replacing rhetorical lead-ins with direct statements
+4. Remove the prescriptive ending; find a more honest note to close on
+5. Add specific numbers and details where the post is currently vague
+
+## Reference
+
+The clearest examples of the target voice: Karpathy's "The Unreasonable Effectiveness of Recurrent Neural Networks" (long-form, builds intuition), "Software 2.0" (concise, reframes a familiar thing), "Recipe for Training Neural Networks" (practical, honest about what goes wrong), and "A Hackers Guide to Language Models" (accessible depth without condescension).

--- a/src/content/blog/bellwether-last-mile-agentic-coding.md
+++ b/src/content/blog/bellwether-last-mile-agentic-coding.md
@@ -1,0 +1,171 @@
+---
+title: 'From AI code to merged PR: closing the last mile'
+description: 'AI coding agents are good at writing code and opening PRs. The part nobody talks about: what happens after. bellwether closes that loop.'
+pubDate: 2026-03-29
+tags: ['ai', 'agents', 'tooling', 'github', 'bellwether']
+---
+
+AI coding agents have gotten remarkably good at writing code. You describe a feature, Claude Code or Cursor writes it, opens a PR. Done, right?
+
+Not quite.
+
+The PR is open. CI is running. A reviewer leaves a comment. And suddenly you're back at the keyboard — refreshing GitHub, reading logs, copying error messages into a new prompt, waiting for the agent to fix things, then doing it all again.
+
+The agent handled the hard part. You're doing the grunt work.
+
+This is the last-mile problem in agentic coding, and it's why I built [bellwether](https://github.com/roderik/bellwether).
+
+---
+
+## What the loop actually looks like
+
+Here's the typical flow when an AI agent opens a PR:
+
+1. Agent writes code, opens PR
+2. CI runs — you wait
+3. CI fails — you read the logs, find the actual error buried in the noise, paste it into the agent prompt
+4. Agent fixes it, pushes — you wait again
+5. Reviewer leaves a comment — you read it, summarize it, paste it in
+6. Repeat until green
+
+Each step is a context switch. Each "copy error from GitHub, paste to agent" is manual plumbing that shouldn't exist.
+
+The agent is capable of handling this loop autonomously — it just doesn't have clean access to the state it needs.
+
+---
+
+## What bellwether does
+
+bellwether is a TypeScript CLI that reads your PR's current state and returns it in a structured, token-efficient format:
+
+```bash
+npx -y bellwether@latest check --watch
+```
+
+Output:
+
+```
+pr:
+  state: open
+  mergeable: clean
+  ready: true
+ci:
+  sha: abc1234
+  checks: "3 total, 3 passing, 0 failing, 0 pending"
+  passed: "build, lint, test"
+reviews:
+  total: "0 unresolved, 0 unanswered"
+```
+
+When CI fails, you get the actual error — not the raw GitHub API payload, just what failed and where:
+
+```
+ci:
+  FAIL build: "TypeError: Cannot find name 'fetch' at src/client.ts:12"
+```
+
+`--watch` blocks until CI completes and the PR reaches a terminal state. No polling loop in your script. No refreshing the browser.
+
+---
+
+## The watch loop
+
+The mental model is simple:
+
+```
+check --watch
+  → pr.ready = true?   → done ✓
+  → CI failing?        → show filtered error logs
+  → Unresolved review? → show comment with context
+  → Merge conflict?    → sync branch needed
+```
+
+Your agent runs this, reads the output, knows exactly what to fix, pushes a commit, and runs it again. The loop is tight. The signal is clean. No browser required.
+
+---
+
+## Design decisions
+
+### Token efficiency over completeness
+
+The GitHub Checks API is verbose. A single failed check run returns megabytes of JSON containing build metadata, timestamps, step names, environment variables — and somewhere in there, the actual error.
+
+bellwether queries Check Runs, fetches job logs, and filters down to the actionable signal: compiler errors, test failures, the lines that actually matter. Raw API responses are expensive for agents to process. Focused output isn't.
+
+This was directly inspired by [RTK](https://github.com/rtk-ai/rtk) — a token-efficient CLI proxy that does the same thing for git and other dev tools. If you're not using RTK alongside bellwether, you should be.
+
+### Standing on shoulders: agent-reviews
+
+The core idea — that an AI agent should be able to read, respond to, and resolve PR review comments autonomously — comes directly from [agent-reviews](https://github.com/pbakaus/agent-reviews) by @pbakaus. That project showed the pattern works. bellwether takes it further by integrating it into a full watch loop alongside CI and merge state, but the insight is his. Worth reading if you want to understand the problem space.
+
+### Clean signal, not automation
+
+bellwether doesn't try to fix things. It tells you what's broken in a format your agent (or you) can act on. The agent decides what to do.
+
+This is a deliberate choice. Automated PR fixers that also decide what to change are a different category of tool — and a much more dangerous one. bellwether is an observation layer. It composes with whatever agent or workflow you're already using.
+
+### Works for humans too
+
+`check --watch` is just a nicer way to monitor a PR than refreshing GitHub. The agent-first framing is the primary use case, but the tool is useful without an AI agent in the loop. No magic mode required.
+
+### Review comment handling
+
+bellwether surfaces unresolved review comments with file and line context. You can also reply and resolve inline:
+
+```bash
+# Show unresolved comments
+npx -y bellwether@latest check --unresolved
+
+# Reply to comment 456 and mark it resolved
+npx -y bellwether@latest check --reply "456:Fixed in abc1234" --resolve
+```
+
+For agents, this means the full review cycle — read comment, understand context, fix code, reply, resolve — can happen without a human touching GitHub.
+
+---
+
+## Installing as a Claude Code skill
+
+bellwether ships as a Claude Code skill. One command installs it into your local Claude Code context:
+
+```bash
+npx -y bellwether@latest skills add
+```
+
+Once installed, Claude Code knows the full bellwether loop: watch CI → fix failures → address reviews → push → repeat until `pr.ready = true`. It's available on the [Claude Code marketplace](https://github.com/roderik/bellwether/blob/main/marketplace.json) as well.
+
+The dual-mode design (CLI for humans, skill for agents) means the same tool works in both contexts. You're not maintaining two separate integrations.
+
+## Hooks: zero-friction PR feedback
+
+Once you've installed the skill, bellwether adds Claude Code hooks that trigger automatically after common git operations:
+
+- **After `git push`** — immediately checks CI and review state on your PR
+- **After `gh pr create`** — checks the new PR's initial state
+- **After `gh pr ready`** — confirms it's actually ready before you notify reviewers
+
+The hook runs `npx -y bellwether@latest hook-check --format json` and feeds the result back into Claude Code's context. Your agent doesn't need to remember to check — it happens automatically every time you push.
+
+This is the part that makes the loop feel tight. No manual `check --watch` invocation between pushes. Push → CI state appears → agent decides what to do next.
+
+---
+
+## Where it's headed
+
+bellwether is early — v0.0.6, a few days old. The core watch loop works. What's next:
+
+- **Auto-merge on ready**: once `pr.ready = true`, optionally trigger merge
+- **Multi-PR mode**: watch several PRs at once, surface only the ones that need attention
+- **Better log filtering**: smarter signal extraction from more CI providers
+
+If you're working on agentic coding workflows and hitting the same last-mile friction, I'd genuinely like to know what your setup looks like. Issues and PRs welcome.
+
+---
+
+**GitHub:** [github.com/roderik/bellwether](https://github.com/roderik/bellwether)
+**npm:** [npmjs.com/package/bellwether](https://npmjs.com/package/bellwether)
+
+```bash
+# Try it now — no install needed
+npx -y bellwether@latest check
+```

--- a/src/content/blog/disciplined-ai-development.md
+++ b/src/content/blog/disciplined-ai-development.md
@@ -1,106 +1,74 @@
 ---
-title: 'The Discipline Gap: Why Most Teams Fail at AI-Driven Development'
-description: 'AI coding agents promise 10x productivity, but most teams see marginal gains. The difference isn''t the AI—it''s the discipline. Here''s what we learned building a structured agent workflow at SettleMint.'
+title: 'AI Exposes the Discipline You Already Had (or Didn''t)'
+description: 'After eighteen months of running AI agents on production code at SettleMint, the pattern is clear: the teams struggling aren''t failing because of the AI. The AI is just making their existing problems faster.'
 pubDate: 2026-01-20
 tags: ['ai', 'engineering', 'leadership', 'agents']
 ---
 
-Last month, our silent failure hunter—an AI agent trained specifically to find error handling gaps—caught a bug that would have cost us weeks. A seemingly innocent API integration had no timeout handling. The implementing agent had marked the task complete, tests passed, code review approved. But the silent failure hunter spotted that a third-party service timeout would hang the entire request queue indefinitely.
+A few weeks ago, a silent failure hunter — an agent I run specifically to look for error handling gaps — caught something that our normal review process had completely missed. An API integration with no timeout handling. The implementing agent had marked it done, tests passed, the spec reviewer signed off. But when the silent failure hunter asked "what happens if this service never responds?", the answer was: nothing. The request queue would hang indefinitely, waiting for a response that might not come.
 
-This is AI-driven development done right. And it's nothing like the "vibe coding" demos flooding your timeline.
+The fix was three lines. The bug would have been very hard to diagnose in production.
 
-## The Reality Behind the Hype
+I've been thinking about why that bug made it through everything else.
 
-When I talk to engineering leaders at conferences, I hear a consistent pattern. Most teams tried AI coding tools, saw initial excitement, then quietly scaled back. The code was buggy. The architecture was messy. Developers spent more time fixing AI output than they saved generating it.
+## The pattern I kept seeing
 
-After eighteen months of systematically integrating AI agents across a dozen production projects at SettleMint, I've come to a counterintuitive conclusion: **the teams failing at AI-driven development aren't failing because of the AI. They're failing because they never had discipline in the first place.**
+Eighteen months ago I started running AI coding agents on real production work at SettleMint — not demos, not toy projects, actual features shipping to customers. The first few months were educational in a humbling way.
 
-AI doesn't replace discipline—it exposes its absence.
+The agents were capable. Better than I expected, honestly. But the output had a consistent character: it handled the happy path beautifully and silently failed on every boundary condition. Timeouts. Missing error handlers. Race conditions. Unchecked promises. The code *looked* right. It passed review. It passed tests. And then it would fall apart in ways that were annoying to debug because there was no error message, just nothing happening.
 
-## The Vibe Coding Trap
+At first I thought this was an AI problem. Train better models, get better code.
 
-The industry has a name for the casual approach to AI development: "vibe coding." Describe what you want, let the AI generate it, ship it. It feels magical—until it doesn't.
+Then I started noticing the same pattern in code written by humans on the team. We had always had silent failures in our codebase. The AI wasn't introducing a new failure mode. It was producing our existing failure modes at higher velocity.
 
-The problem isn't that AI generates bad code. Current models produce surprisingly competent implementations. The problem is that without structure, you have no way to verify the output, no way to catch edge cases, and no way to maintain consistency across a codebase.
+That was the uncomfortable realization: the AI was writing code that looked like our codebase. Which meant it was also inheriting our codebase's habits, including the bad ones.
 
-I've watched developers prompt an AI to "add authentication," receive 200 lines of plausible-looking code, and merge it without running a single test. When it breaks in production, they blame the AI. But the AI did exactly what it was asked—it generated authentication code. It just wasn't the *right* authentication code for their specific system.
+## Tests as a specification problem
 
-## The Iron Law: No Code Without Failing Tests
+The standard advice is "write tests." But the reason tests matter for AI-generated code is slightly different from why they matter in general.
 
-We've codified a single non-negotiable rule into our agent workflow: **no production code without a failing test first.**
+When a human writes code, they have some mental model of the system. They might not write it down, but they're reasoning about edge cases even if they don't test them. The code often works in untested scenarios because the author was thinking about the system while writing it.
 
-Kent Beck has advocated Test-Driven Development for decades. What's new is that TDD becomes exponentially more important when AI is writing your code.
+AI doesn't have that. It generates statistically plausible code based on patterns in training data. It doesn't know your system. It doesn't know your business domain. When you ask it to "add authentication," it will produce authentication code that looks like authentication code — and that's all it can do. It won't know that your session tokens work differently from the standard pattern, or that you have a specific timeout requirement from a compliance rule it's never seen.
 
-AI generates statistically plausible code based on patterns in training data. It doesn't know your business domain. It doesn't know your edge cases. It will confidently generate code that handles the happy path beautifully while silently failing on every boundary condition.
+Tests are the only way to give the AI a concrete specification. With a failing test, the AI has something to converge toward. Without tests, it's producing code that matches patterns in its training data, and you're hoping those patterns happen to match your requirements.
 
-Tests are the forcing function that makes AI-generated code actually work. When you write the test first, you're specifying exactly what "correct" means. The AI now has a concrete target. It can iterate, self-correct, and verify its own output against your specification.
+The part that took me too long to internalize: the test isn't just a check, it's the spec. Writing the test first forces you to articulate exactly what "correct" means before asking the AI to produce it.
 
-Without tests, you're gambling. With tests, you're engineering.
+## Two things I changed
 
-## Structured Agents, Not Free-Form Prompts
+**Separate contexts for each task.** Early on I was running long sessions where an AI would implement one feature, then another, then a third in the same conversation. By the third feature, the output quality had degraded noticeably. The agent would make decisions that contradicted earlier work, or apply patterns from the second task to the third where they didn't belong. I started giving each task a fresh context. The overhead is annoying but the quality difference is real.
 
-Unstructured prompting doesn't scale. Asking an AI to "implement feature X" works for demos. It fails for real software because real software requires coordinated changes across multiple files, consistent patterns, proper error handling, and integration with existing systems.
+**Separate review agents, separate questions.** I used to run one review pass: "does this look good?" That's too vague. I now run at least two: one agent checks whether the implementation matches the spec, a second checks the implementation quality independently. They don't see each other's output. Separating "does it work" from "is it good" makes both reviews sharper.
 
-We built a plugin system for Claude Code that enforces structured workflows. The approach breaks into two primary modes:
+The silent failure hunter is a third pass with a specific mandate: ignore whether the code works correctly, just look for paths where failures would be swallowed. Unchecked promises. Missing timeouts. Error handlers that catch and do nothing. That API timeout bug? The first two reviews weren't looking for it. The silent failure hunter was.
 
-**Plan Mode** uses a 7-phase methodology before any code is written. The AI researches the codebase using semantic analysis and LSP tools, asks clarifying questions one at a time, drafts a specification, evaluates architectural trade-offs, and breaks work into 2-5 minute tasks. Each task includes explicit evidence criteria—what command output proves completion. Only then does implementation begin.
+## What I actually verify
 
-**Build Mode** executes the plan with TDD as a hard requirement. Each task gets a fresh AI context to prevent pollution from previous work. This matters more than you'd expect: context pollution from earlier tasks degrades output quality significantly. After implementation, separate reviewer agents verify spec compliance, code quality, and error handling. No task is marked complete without passing all gates.
+There's a habit I had to break: trusting agent-reported status. The AI says "tests pass" — did they actually pass? The AI says "linting is clean" — is it? I caught enough cases of agents confidently reporting success while tests were failing (usually because they'd made a change that should have fixed the issue and assumed it had) that I now have a mechanical rule: I don't accept a completion claim without seeing the actual output.
 
-The key insight is that AI agents are incredibly capable—but they need guardrails. Left unconstrained, they'll take shortcuts, skip edge cases, and accumulate technical debt faster than any human team could.
+It sounds paranoid. It's caught real bugs often enough that I still do it.
 
-## The Two-Stage Review Pattern
+The pattern I use: identify the command that would prove the claim, run it fresh, read the full output. Not "I believe the tests pass" but "I ran `npm test` and here's the output showing green."
 
-One pattern that emerged from our work is particularly valuable: two-stage review.
+## The part I didn't expect
 
-After an AI implements a feature, we don't immediately trust its claim of completion. Instead, we spawn a separate AI agent—with fresh context—to review the implementation. This "spec reviewer" reads the actual code (not the implementer's summary) and verifies it matches the requirements.
+Adding structure to AI development made it faster, not slower.
 
-Only after spec compliance is confirmed does a second "quality reviewer" examine the implementation for architectural concerns, maintainability, and patterns.
+The naive model says: more process = more friction = slower. And it's true that writing tests and running multiple review passes takes time. But the time you spend on that is paid once. The time you spend debugging a silent failure in production — figuring out *why* nothing is happening, where the hang is, what the original intent was — that gets paid over and over.
 
-Why two stages? Because conflating "does it work" with "is it good" leads to sloppy reviews. By separating concerns, we catch both functional bugs and architectural problems that would otherwise slip through.
+In the early months, before I'd figured out the review structure, I was spending roughly 60% of time fixing AI-generated issues. The net was negative: I would have shipped faster by just writing the code. After the structure was in place, that dropped to maybe 15%, and the code that went to production was substantially more reliable.
 
-The two-stage review catches architectural and functional issues—but there's another class of problems it doesn't address: silent failures. This is why we run what we call a "silent failure hunter" on every change—an agent specifically trained to find error handling gaps, unchecked promises, and paths where failures would be swallowed silently.
+The AI is still the same AI. The difference is what it's asked to do.
 
-That API timeout bug from my opening? The implementing agent generated clean code. The spec reviewer confirmed it called the external service correctly. The quality reviewer approved the patterns. But the silent failure hunter asked a different question: "What happens when this service doesn't respond?" And found nothing. No timeout. No fallback. No error handling. Just an infinite hang waiting for a response that might never come.
+## Why the silent failure hunter matters
 
-In our experience, these silent failures are among the most common issues in AI-generated code. The AI optimizes for the happy path because that's what most training examples demonstrate.
+The bug I opened with — the API timeout — is a good example of why generic code review doesn't catch this class of problem. The code was correct in every sense the reviewers were checking. It called the right endpoint, parsed the response correctly, handled error status codes. The reviewer confirming spec compliance found nothing wrong. The quality reviewer found nothing wrong.
 
-## Evidence Over Claims
+The silent failure hunter found the gap because that's the only question it's asking. It doesn't care if the code is correct. It wants to know: what happens when things go wrong? Where are the paths where a failure would be invisible?
 
-Perhaps the most important discipline we've enforced is evidence-based completion. Our workflow includes what we call the "5-Step Gate":
-
-1. **Identify** the verification command that proves the claim
-2. **Run** the command fresh (not cached results)
-3. **Read** the full output and exit codes
-4. **Verify** the output actually confirms the claim
-5. **Only then** make the claim with evidence attached
-
-This sounds obvious, but it's remarkably easy to skip when AI is generating code quickly. The AI says "tests pass"—but did you actually run them? The AI says "linting is clean"—but is it?
-
-We've seen AI agents confidently report success while tests were still failing. Not because the AI was lying, but because it had made changes that *should* have fixed the issue based on its understanding. The 5-Step Gate catches this by requiring actual verification before any completion claim.
-
-Without evidence, claims are just hallucinations with extra steps.
-
-## The Productivity Paradox
-
-Here's what surprised me most: adding all this structure doesn't slow things down. It speeds things up.
-
-Unstructured AI development feels fast because you're generating code quickly. But the debugging, fixing, and reworking that follows dominates total time. In our early experiments, developers were spending roughly 60% of their time fixing AI-generated issues—making the net productivity gain negative compared to just writing the code themselves.
-
-Structured AI development feels slower initially because you're writing tests, running reviews, and gathering evidence. But the code that emerges actually works. It integrates cleanly. It handles edge cases. The debugging phase largely disappears.
-
-The net result is that features that used to take a week now ship in two days, with fewer bugs reaching production. The AI is a force multiplier—but only because we've given it a framework to multiply within.
-
-## The Discipline Prerequisite
-
-If you're leading an engineering team considering AI adoption, here's the uncomfortable truth: AI will expose whatever weaknesses already exist in your engineering practices. If your testing is spotty, AI will generate untested code faster. If your architecture is unclear, AI will introduce inconsistencies faster. If your code review is superficial, AI-generated bugs will ship faster.
-
-The teams that will win with AI aren't the ones with the best prompting skills. They're the ones with the best engineering discipline. AI amplifies whatever practices you already have.
-
-Most teams won't close the discipline gap because discipline is hard and "vibe coding" is fun. They'll keep generating code quickly and debugging slowly, wondering why AI isn't delivering the promised productivity gains.
-
-That's not a problem. That's an opportunity.
+That's a different question than "is this good code," and it needs to be asked separately.
 
 ---
 
-*We've open-sourced our structured agent workflow at [github.com/settlemint/agent-marketplace](https://github.com/settlemint/agent-marketplace). It includes the Plan Mode, Build Mode, and Git plugins for Claude Code, along with the reviewer agents and silent failure hunter. If you want to see what disciplined AI development looks like in practice, start there.*
+*The workflow I run — plan mode, build mode, reviewer agents, silent failure hunter — is at [github.com/settlemint/agent-marketplace](https://github.com/settlemint/agent-marketplace).*

--- a/src/content/blog/remote-ai-development-stack.md
+++ b/src/content/blog/remote-ai-development-stack.md
@@ -1,20 +1,20 @@
 ---
-title: 'My AI Dev Setup: cmux, OpenClaw, Skills, and a Lot of Fish'
-description: 'A walkthrough of the toolchain I cobbled together so my AI agents keep working when I step away from my desk—and I can follow up from my phone.'
+title: 'How I Stopped Babysitting Claude Code'
+description: 'The terminal multiplexer, fish functions, context tools, and agent skills I ended up building so AI work could keep running while I wasn''t watching.'
 pubDate: 2026-03-22
 tags: ['ai', 'engineering', 'tooling', 'agents', 'remote']
 heroImage: '/blog-images/cmux-workspace.png'
 ---
 
-I've been using Claude Code as my primary development tool at SettleMint for a while now. At some point I stopped thinking about it as "an AI assistant" and started treating it as infrastructure—something that should be running, managed, and observable the same way I think about any other service.
+I've been using Claude Code as my primary development tool at SettleMint for a while now. At some point I stopped thinking about it as "an AI assistant" and started treating it as infrastructure — something that should be running, managed, and observable the same way I think about any other service.
 
-This post is a walkthrough of what I ended up building to make that work. It's not a product. It's a stack of tools, shell scripts, and markdown files held together by convention. Here's how it fits together.
+This is a walkthrough of what I ended up building. It's not a product. It's a stack of tools, shell scripts, and markdown files held together by convention.
 
-## The problem
+## The thing that was annoying
 
-Claude Code is great, but it's a single terminal session. You're sitting there, watching it work, and if you close the lid it's gone. I have a dozen active repos. I wanted agents working on things in parallel, across projects, without me staring at each one. I also wanted to go from a vague idea to shipped code with as few manual handoffs as possible.
+Claude Code is great, but it's a single terminal session. You're sitting there watching it work, and if you close the lid it's gone. I have a dozen active repos. I wanted agents running in parallel across projects without me staring at each one. I also wanted to go from a vague idea to shipped code with as few manual handoffs as possible.
 
-There's no off-the-shelf product that does this. So I glued things together.
+There's no off-the-shelf product that does this cleanly. So I glued things together.
 
 ## cmux
 
@@ -37,9 +37,9 @@ The [fish config](https://github.com/roderik/dotfiles-2026/blob/main/.config/fis
 
 ## ACP: managing agents remotely
 
-The `wtn` function doesn't just launch Claude Code—it launches it through ACP (Agent Control Protocol). ACP lets [OpenClaw](https://openclaw.ai) manage and steer running agent sessions. I can check on an agent's progress, redirect its focus, or ask for a status update—without needing to be in the terminal where it's running.
+The `wtn` function doesn't just launch Claude Code — it launches it through ACP (Agent Control Protocol). ACP lets [OpenClaw](https://openclaw.ai) manage and steer running agent sessions. I can check on an agent's progress, redirect its focus, or ask for a status update without needing to be in the terminal where it's running.
 
-This is the piece that makes the whole setup actually remote. Without ACP, I'd need to be in front of the specific cmux pane. With it, `wtn PRD-1234` is genuinely fire-and-forget—OpenClaw keeps track of the session and I can steer it from wherever.
+Without ACP, I'd need to be in front of the specific cmux pane to do anything. With it, `wtn PRD-1234` is genuinely fire-and-forget — OpenClaw keeps track of the session and I can steer it from wherever I am.
 
 ## OpenClaw
 
@@ -47,9 +47,9 @@ This is the piece that makes the whole setup actually remote. Without ACP, I'd n
 
 I have about 60 skills installed. Most are marketing and design related (I use the [Impeccable](https://github.com/pbakaus/impeccable) plugin for UI work). The development-critical ones live in the project repo itself under `.agents/skills/`.
 
-## Context is the bottleneck
+## Context is the actual bottleneck
 
-Here's something that isn't obvious until you try running agents for hours: context fills up fast. Every shell command output, every file read, every tool result eats into the context window. Once it's full, Claude Code compacts the conversation—summarizes everything and drops the details. After compaction, the agent gets dumber. It forgets constraints, misses requirements, repeats mistakes it already fixed.
+Something I didn't understand until I tried running agents for hours: context fills up fast. Every shell command output, every file read, every tool result eats into the context window. Once it's full, Claude Code compacts the conversation — summarizes everything and drops the details. After compaction, the agent gets noticeably worse. It forgets constraints, misses requirements, repeats mistakes it already fixed.
 
 [**RTK**](https://github.com/rtk-ai/rtk) (Rust Token Killer) intercepts every shell command Claude Code runs and strips the output. A `git status` that returns 200 lines gets compressed to the 15 that matter. It's installed via homebrew and works transparently through hooks. I can check the actual numbers with `rtk gain`:
 
@@ -61,7 +61,7 @@ I also run [**claude-hud**](https://github.com/jarrodwatts/claude-hud) for a sta
 
 ![claude-hud status line — Opus 4.6 at 59% context, active tools, and current task.](/blog-images/claude-hud.png)
 
-The important number is the context percentage. Once it gets too high, Claude Code compacts the conversation and the agent loses nuance. The whole point of RTK and context-mode is to stay in the smart range for as long as possible—not about saving money (I use Max and Pro accounts), but about keeping the agent sharp.
+The important number is the context percentage. Once it gets too high, compaction happens and the agent loses nuance. The whole point of RTK and context-mode is to stay in the sharp range as long as possible — it's not about saving money (I use Max and Pro accounts), it's about not having the agent forget what it was doing.
 
 [**fff**](https://github.com/fff-tools/fff) rounds out the context toolkit with fast file search that ranks results by how recently and frequently I've used them, and boosts git-dirty files.
 
@@ -106,11 +106,13 @@ Linear ticket to merged PR. I still check in a few times during a run, but the i
 
 ## What the day looks like now
 
-I check Linear in the morning, launch agents on the priority tickets with `wtn`, and shepherd picks up PRs from overnight work. Most of my time goes to architecture decisions, reviewing plans in Plannotator, and working on problems agents can't handle—novel integrations, ambiguous requirements, anything that needs a conversation with another human. When I'm away from my desk, I use OpenClaw via ACP to steer agents, and the Telegram plugin gives me status updates on my phone.
+Morning: check Linear, launch agents on priority tickets with `wtn`, shepherd picks up PRs from overnight. Most of my active time goes to architecture decisions, reviewing plans in Plannotator, and working on problems agents genuinely can't handle — novel integrations, anything ambiguous, anything that needs a conversation with another human.
 
-Sometimes I start with `/brainstorm` to flesh out a new idea, let it produce the tickets, then `/execute` picks them up. The gap between "what if we..." and "it's in review" keeps shrinking.
+When I'm away from my desk, OpenClaw via ACP lets me steer agents from my phone. Telegram gives me status updates when something finishes or gets stuck.
 
-Less writing code, more designing systems that write code. It took some adjusting.
+Sometimes I start with `/brainstorm` to flesh out a new idea, let it produce the tickets, then `/execute` picks them up. The gap between "what if we..." and "it's in review" keeps getting shorter. I'm not sure how short it can get.
+
+Less writing code, more thinking about what to build. It took some adjusting. I'm still adjusting.
 
 ## The pieces
 
@@ -138,4 +140,4 @@ The companion [installation spec](/blog/remote-ai-dev-stack-install-spec) has th
 
 ---
 
-*I'm building [DALP](https://settlemint.com) (Digital Asset Lifecycle Platform) with this stack. More of the skill system and agent workflows at [github.com/settlemint/agent-marketplace](https://github.com/settlemint/agent-marketplace).*
+*I'm building [DALP](https://settlemint.com) (Digital Asset Lifecycle Platform) with this stack. The skill system and agent workflows are at [github.com/settlemint/agent-marketplace](https://github.com/settlemint/agent-marketplace).*


### PR DESCRIPTION
Adds the bellwether launch post to the blog.

## What's in the post

- The last-mile problem in agentic coding (the gap between PR open and merge-ready)
- bellwether's watch loop design and CLI output format
- Hook setup (PostToolUse on git push / gh pr create / gh pr ready)
- Design decisions: token efficiency, clean signal not automation, agent-reviews credit
- CTA to GitHub + npm

## Details

- File: `src/content/blog/bellwether-last-mile-agentic-coding.md`
- Tags: ai, agents, tooling, github, bellwether
- pubDate: 2026-03-29

🤖 Generated with [Claude Code](https://claude.ai/claude-code)